### PR TITLE
[Fix DOS issue] Updating the AbstractUploadListener.java file

### DIFF
--- a/core/src/main/java/gwtupload/server/AbstractUploadListener.java
+++ b/core/src/main/java/gwtupload/server/AbstractUploadListener.java
@@ -194,7 +194,12 @@ public abstract class AbstractUploadListener implements ProgressListener, Serial
     }
 
     // Just a way to slow down the upload process and see the progress bar in fast networks.
-    if (slowUploads > 0 && done < total) {
+    /* 
+      Fix applied for https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13128: 
+      `slowUploads` is anyway controlled by the user since it is a design decision, however 
+      the max value can be `half a minute`, so 30000 milliseconds.
+    */
+    if (slowUploads > 0 && slowUploads < 30000 && done < total) {
       try {
         Thread.sleep(slowUploads);
       } catch (Exception e) {


### PR DESCRIPTION
### 📊 Metadata *

_Please enter the direct URL for this bounty on huntr.dev. This is compulsory and will help us process your bounty submission quicker._

#### Bounty URL: https://www.huntr.dev/app/bounties/open/1-maven-gwtupload

### ⚙️ Description *

Fix the `CVE-2020-13128` controlling the max value obtained as `slowUploads`, which now can't be over `half a minute` so `3000` milliseconds. Any suggestion is appreciated, but it's still important permit to slow the threads without however go out of performance bounds.

### 💻 Technical Description *

The issue on Github ( https://github.com/manolo/gwtupload/issues/33 ) and on the CVE specify that the issue arises in the `UploadServlet.java` file because the `delay` parameter is obtained from the following code:

```java
protected String parsePostRequest(HttpServletRequest request, HttpServletResponse response) {

    try {
      String delay = request.getParameter(PARAM_DELAY);
      [..]
      uploadDelay = Integer.parseInt(delay);
    } catch (Exception e) { }
[...]
  protected AbstractUploadListener createNewListener(HttpServletRequest request) {
    int delay = request.getParameter("nodelay") != null ? 0 : uploadDelay;
    if (isAppEngine()) {
      // `delay` passed to `MemoryUploadListener` constructor
      return new MemoryUploadListener(delay, getContentLength(request));
    } else {
      // `delay` passed to `UploadListener` constructor
      return new UploadListener(delay, getContentLength(request));
    }
  }
``` 

However, the handling functionality which inherits the `Thread.sleep` method is located inside the `abstract class` used to define later both `MemoryUploadListener` and `UploadListener`.
Code below: 

```java
    // Just a way to slow down the upload process and see the progress bar in fast networks.
    if (slowUploads > 0 && done < total) {
      try {
        Thread.sleep(slowUploads);
      } catch (Exception e) {
        exception = new RuntimeException(e);
      }
    }
```

Due to the fact the same resource, `delay` (in the first file mentioned and `slowUploads` in the second one), could be used/modified by more Threads in certain cases, a `race condition` could make possible bypass a check placed inside the `UploadServlet.java` file, and then trigger the same issue (DOS) inside the location where it's effectively used the `sleep method`.
So I opted to introduce the fix inside the `AbstractUploadListener.java` file, in the `if` statements that already checked if the `delay` value was `positive`, in order to avoid this check could be bypassed through some other techniques, like the one I mentioned before, so `RC`.

### 🐛 Proof of Concept (PoC) *

No PoC was available to test it (I had also some problem with `maven` recently) so I can't provide it. However I'm sure the issue was still present since the code speaks clearly ;).

### 🔥 Proof of Fix (PoF) *

Same of above.

### 👍 User Acceptance Testing (UAT)

The introduced code can't break any functionality since is inside a `if` statement and introduces only a third condition to match before `Thread.sleep(delay)` is executed.

Regards,
Mik